### PR TITLE
Fix model save path and profiler flag

### DIFF
--- a/cd4ml/filenames.py
+++ b/cd4ml/filenames.py
@@ -21,6 +21,6 @@ file_names = {
     'metrics': '%s/results/metrics.json' % data_dir,
     'train': '%s/splitter/train.csv' % data_dir,
     'validation': '%s/splitter/validation.csv' % data_dir,
-    'model': '%s/' % model_dir,
+    'model': '%s/model.h5' % model_dir,
     'ml_params': 'model_params.py'
 }

--- a/run_python_script.py
+++ b/run_python_script.py
@@ -7,10 +7,8 @@ script_names_str = script_names.__repr__()
 
 
 def run_python_script(script_name, *args, **kwargs):
-    if 'profiler' in kwargs:
-        use_profiler = True
-    else:
-        use_profiler = False
+    """Execute a helper script optionally using the cProfile profiler."""
+    use_profiler = kwargs.get('profiler', False)
 
     if script_name == 'show':
         print("\nAvailable scripts\n----------------")
@@ -19,7 +17,7 @@ def run_python_script(script_name, *args, **kwargs):
 
         exit(0)
 
-    if profiler:
+    if use_profiler:
         print("running with profiler")
 
     if script_name == "pipeline":
@@ -33,7 +31,7 @@ def run_python_script(script_name, *args, **kwargs):
                                                                  script_names_str)
         raise ValueError(message)
 
-    if profiler:
+    if use_profiler:
         command = "script.main(*args)"
         filename = "%s.prof" % script_name
         cProfile.runctx(command, None, locals(), filename=filename)

--- a/source/machine_learning/validate.py
+++ b/source/machine_learning/validate.py
@@ -17,9 +17,7 @@ def write_predictions_and_score(evaluation_metrics):
 def write_model(model):
     filename = file_names['model']
     print("Writing to {}".format(filename))
-    # FIX Unable to create file (unable to open file: name = 'data/models/', errno = 21,
-    # error message = 'Is a directory', flags = 13, o_flags = 242)
-    # model.save(filename)
+    model.save(filename)
 
 
 def validate(model, x_normal, x_attack, x_normal_test, track):


### PR DESCRIPTION
## Summary
- correct use of profiler flag in `run_python_script`
- save trained models to `data/models/model.h5`

## Testing
- `bash run_tests.sh` *(fails: unrecognized pytest args and missing flake8)*

------
https://chatgpt.com/codex/tasks/task_e_6840429643e483228dc615f54ca99261