### PR TITLE
Fix profiler flag variable

### DIFF
--- a/run_python_script.py
+++ b/run_python_script.py
@@ -41,9 +41,9 @@ def run_python_script(script_name, *args, **kwargs):
 
 
 if __name__ == "__main__":
-    profiler = ' -p' in ' '.join(sys.argv)
+    use_profiler = ' -p' in ' '.join(sys.argv)
     script = sys.argv[1]
     arguments = sys.argv[2:]
-    # remove the profile flag now that profiler is on
+    # remove the profile flag now that use_profiler is on
     arguments = [i for i in arguments if i != '-p']
-    run_python_script(script, arguments, profiler=profiler)
+    run_python_script(script, arguments, profiler=use_profiler)


### PR DESCRIPTION
## Summary
- correct profiler variable handling in run_python_script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404443d45c8322adeedc7e1822255f