### PR TITLE
Improve download test with data loader

### DIFF
--- a/test/ingestion/download.py
+++ b/test/ingestion/download.py
@@ -1,3 +1,12 @@
-def test_stream_raw_data():
+import pandas as pd
+from unittest.mock import patch
+from source.machine_learning.adquire_data import read_data
 
-    assert df.empty == False
+
+def test_stream_raw_data():
+    # create a small DataFrame with the correct number of columns
+    sample_df = pd.DataFrame([list(range(42))])
+    with patch('source.machine_learning.adquire_data.get_file', return_value='dummy_path'), \
+         patch('pandas.read_csv', return_value=sample_df.copy()):
+        df = read_data()
+    assert not df.empty


### PR DESCRIPTION
## Summary
- test data loading via `read_data`
- mock out network calls with a synthetic DataFrame

## Testing
- `./run_tests.sh` *(fails: flake8 and pytest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684044455d988322a98f5bc5c756f2ee